### PR TITLE
Modify padding from the award image to be on the panel instead

### DIFF
--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -28,8 +28,6 @@ class AwardIssued extends BaseMixin(LitElement) {
 				width: ${unsafeCSS(BadgeImageSize)}px;
 				padding-right: 3px;
 				vertical-align: middle;
-				padding-top: 12px;
-				padding-bottom: 12px;
 			}
 			`
 		];

--- a/src/components/leaderboard-row.js
+++ b/src/components/leaderboard-row.js
@@ -93,6 +93,8 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 				padding-left: ${unsafeCSS(PanelPadding)}px;
 				background-color: var(--d2l-color-sylvite);
 				border-top: 1px solid var(--d2l-color-mica);
+				padding-top: 12px;
+				padding-bottom: 12px;
 			}
 			.noMargin {
 				margin: unset  !important;


### PR DESCRIPTION
* This was causing extra padding on the full view on each row

This is the design spec
https://app.zeplin.io/project/5e5e8d0faf422b653ba8422b/screen/5e821fa6753a246b8b043896

Old
![old](https://user-images.githubusercontent.com/17279735/78404749-08868300-75cd-11ea-8182-61216d6ad051.png)


New
![new](https://user-images.githubusercontent.com/17279735/78404757-0c1a0a00-75cd-11ea-9d52-2854c6b1e10f.png)