### PR TITLE
Revert accidental check-in of package-lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3159,25 +3159,10 @@
       "version": "github:BrightspaceUI/tooltip#fb4ac53db317dad3d1056808025358d7905acc41",
       "from": "github:BrightspaceUI/tooltip#semver:^3",
       "requires": {
-        "@brightspace-ui/core": "^1.38",
-        "@polymer/polymer": "^3.0.0"
-      },
-      "dependencies": {
-        "@brightspace-ui/core": {
-          "version": "1.43.3",
-          "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.43.3.tgz",
-          "integrity": "sha512-7Q/j2qa5VeD1SNaDFGInPyPVl4BH0uXJjeIJZitgDMWes1vga+DbvquO4ksm67Ph/WmSQVDfDXfDYtO/ybE59A==",
-          "requires": {
-            "@brightspace-ui/intl": "^3",
-            "@formatjs/intl-pluralrules": "^1",
-            "@webcomponents/shadycss": "^1",
-            "@webcomponents/webcomponentsjs": "^2",
-            "intl-messageformat": "^7",
-            "lit-element": "^2",
-            "prismjs": "^1",
-            "resize-observer-polyfill": "^1"
-          }
-        }
+        "@brightspace-ui/core": "^1",
+        "@polymer/iron-resizable-behavior": "^3.0.0",
+        "@polymer/polymer": "^3.0.0",
+        "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
     },
     "d2l-typography": {


### PR DESCRIPTION
There were some changes made to package-lock that should be made in a future PR

This is when I checked in the tooltip change
https://github.com/Brightspace/awards-leaderboard-ui/pull/41/files#diff-32607347f8126e6534ebc7ebaec4853d