### PR TITLE
Dialog Close - Must hide the tooltip

### DIFF
--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -49,7 +49,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 			<a href="#" id="${this.badgeId}" @click="${this._awardClick}" class="awardBtn">
 				<img src=${this.awardImageUrl} class='badgeEntry' alt='${this.awardTitle}'></img>
 			</a>
-			<d2l-tooltip for="${this.badgeId}">
+			<d2l-tooltip for="${this.badgeId}" close-on-click>
 				${this.awardTitle}
 			</d2l-tooltip>
     	`;

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -49,7 +49,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 			<a href="#" id="${this.badgeId}" @click="${this._awardClick}" class="awardBtn">
 				<img src=${this.awardImageUrl} class='badgeEntry' alt='${this.awardTitle}'></img>
 			</a>
-			<d2l-tooltip for="${this.badgeId}" disable-focus-lock>
+			<d2l-tooltip for="${this.badgeId}">
 				${this.awardTitle}
 			</d2l-tooltip>
     	`;

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -49,7 +49,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 			<a href="#" id="${this.badgeId}" @click="${this._awardClick}" class="awardBtn">
 				<img src=${this.awardImageUrl} class='badgeEntry' alt='${this.awardTitle}'></img>
 			</a>
-			<d2l-tooltip for="${this.badgeId}" close-on-click>
+			<d2l-tooltip for="${this.badgeId}" disable-focus-lock>
 				${this.awardTitle}
 			</d2l-tooltip>
     	`;

--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -238,7 +238,7 @@ class App extends BaseMixin(LitElement) {
 
 	_closeDialog() {
 		this.awardsDialogOpen = false;
-		setTimeout(() => { console.log(document.activeElement); }, 200);	
+		requestAnimationFrame(() => document.activeElement.blur());
 	}
 
 	_displayEmptyLeaderboard() {

--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -238,6 +238,7 @@ class App extends BaseMixin(LitElement) {
 
 	_closeDialog() {
 		this.awardsDialogOpen = false;
+		setTimeout(() => { console.log(document.activeElement); }, 200);	
 	}
 
 	_displayEmptyLeaderboard() {


### PR DESCRIPTION
Reset focus after dialog close to remove the tooltip - Thanks to help from @AllanKerr 

(Otherwise after closing the dialog, you'd see multiple tooltips)