### PR TITLE
US115049 Accessibility Fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -6,6 +6,7 @@
     "credits.one": "1 credit",
     "emptyBody": "Check back often for the latest rankings.",
     "emptyHeading": "No awards have been earned yet.",
+    "extraCountDescription": "{extracount} more awards",
     "label.credits": "Credits:",
     "label.description": "Description:",
     "label.evidence": "Evidence:",

--- a/src/components/award-details.js
+++ b/src/components/award-details.js
@@ -102,8 +102,8 @@ class AwardDetails extends BaseMixin(LitElement) {
 
 		return html`
 			<div class="awardDetailsRow">
-				<div class="awardImage">	
-					<img src="${this.awardImage}" alt="${this.awardTitle}" />
+				<div class="awardImage">
+					<img src="${this.awardImage}" alt="${this.awardTitle}" tabindex="-1" />
 				</div>
 				<div class="awardDescription">				
 					<div class="d2l-label-text">${this.localize('label.description')}</div> 

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -59,7 +59,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 		this.badgeId = `Badge_${this.award.Award.AwardId}`;
 		return html`
 			<a href="#" id="${this.badgeId}" @click="${this._awardClick}" class="awardBtn">
-				<img id="${this.badgeId}" src=${this.award.Award.ImageData.Path} class='badgeEntry' alt='${this.awardTitle}'></img>
+				<img id="${this.badgeId}" src=${this.award.Award.ImageData.Path} class='badgeEntry' alt='${this.award.Award.Title}'></img>
 			</a>
 			<d2l-tooltip for="${this.badgeId}">${this.award.Award.Title}</d2l-tooltip>
     	`;

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -56,7 +56,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 		) {
 			return;
 		}
-		
+
 		this.badgeId = `Badge_${this.award.Award.AwardId}`;
 		return html`
 			<button 

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -61,6 +61,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 			<button 
 				id="${this.badgeId}" 
 				style="background-image:url(${this.award.Award.ImageData.Path})" 
+				tabindex="0"
 				@click="${this._awardClick}" 
 				class="awardBtn">
 			</button>

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -31,7 +31,11 @@ class AwardIssued extends BaseMixin(LitElement) {
 				cursor: pointer;
 			}
 			.awardBtn {
+				background-color: transparent;
+				background-size: ${unsafeCSS(BadgeImageSize)}px;
+				border: 0px;
 				display: inline-block;
+				height: ${unsafeCSS(BadgeImageSize)}px;
 				margin-right: 3px;
 				text-decoration: none;
 				width: ${unsafeCSS(BadgeImageSize)}px;
@@ -40,11 +44,6 @@ class AwardIssued extends BaseMixin(LitElement) {
 				margin-left: 3px;
 				margin-right: 0px;
 				text-decoration: none;
-			}
-			.badgeEntry {
-				height: ${unsafeCSS(BadgeImageSize)}px;
-				vertical-align: middle;
-				width: ${unsafeCSS(BadgeImageSize)}px;
 			}
 			`
 		];
@@ -56,11 +55,15 @@ class AwardIssued extends BaseMixin(LitElement) {
 		) {
 			return;
 		}
+		
 		this.badgeId = `Badge_${this.award.Award.AwardId}`;
 		return html`
-			<a href="#" id="${this.badgeId}" @click="${this._awardClick}" class="awardBtn">
-				<img id="${this.badgeId}" src=${this.award.Award.ImageData.Path} class='badgeEntry' alt='${this.award.Award.Title}'></img>
-			</a>
+			<button 
+				id="${this.badgeId}" 
+				style="background-image:url(${this.award.Award.ImageData.Path})" 
+				@click="${this._awardClick}" 
+				class="awardBtn">
+			</button>
 			<d2l-tooltip for="${this.badgeId}">${this.award.Award.Title}</d2l-tooltip>
     	`;
 	}

--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -38,6 +38,7 @@ class AwardIssued extends BaseMixin(LitElement) {
 				height: ${unsafeCSS(BadgeImageSize)}px;
 				margin-right: 3px;
 				text-decoration: none;
+				vertical-align: middle;
 				width: ${unsafeCSS(BadgeImageSize)}px;
 			}
 			:host([dir="rtl"]) .awardBtn {

--- a/src/components/leaderboard-row.js
+++ b/src/components/leaderboard-row.js
@@ -121,10 +121,10 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 				border-top: 1px solid var(--d2l-color-mica);
 				margin-top: 11px;
 				margin-bottom: -20px;
-				overflow: hidden;
 				padding-bottom: 12px;
 				padding-left: ${unsafeCSS(PanelPadding)}px;
 				padding-top: 12px;
+				position: relative;
 			}
 			:host([dir="rtl"]) .panel {
 				padding-left: 0px;

--- a/src/components/leaderboard-row.js
+++ b/src/components/leaderboard-row.js
@@ -200,6 +200,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 							<div class='awardRow' ?myAward="${this.myAward}" slot="header">
 								<div 
 									class="awardRank ${fontStyle}" 
+									role="img"
 									?topRank="${this.userData.Rank <= TopStyleLimit}" 
 									aria-label="${this.localize('rankingAria', {rank:`${this.userData.Rank}`})}">
 									${this.userData.Rank}
@@ -230,6 +231,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 				<div class='awardRow' ?myAward="${this.myAward}">
 					<div 
 						class="awardRank ${fontStyle}" 
+						role="img" 
 						?topRank="${this.userData.Rank <= TopStyleLimit}" 
 						aria-label="${this.localize('rankingAria', {rank:`${this.userData.Rank}`})}">
 						${this.userData.Rank}

--- a/src/components/leaderboard-row.js
+++ b/src/components/leaderboard-row.js
@@ -283,7 +283,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 		let additionalAwards;
 		if (extraCount > 0) {
 			additionalAwards = html`
-				+${extraCount}
+				<span role="img" aria-label="${this.localize('extraCountDescription', {extracount:`${extraCount}`})}">+${extraCount}</span>
 			`;
 		}
 		this._displayedBadges = 0;


### PR DESCRIPTION
- Fix screen reader text for Badge images
- "Rank 2" now reads instead of "2"
- Switch badge links to button
- Add other text for Additional badges indicator "+1"
- Fix focus on dialog in FF - Set tabindex=-1 on the image. The dialog focuses on the image and doesn't work correctly in Firefox

Thank you @m6jones for all your help on these!