### PR TITLE
Move resize-aware up a level

### DIFF
--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -39,15 +39,15 @@ class App extends BaseMixin(LitElement) {
 			userId: { type: Number },
 			sortByCreditsConfig: { type: Boolean },
 			doneLoading: { type: Boolean },
-			_mobile: {
+			mobile: {
 				type: Boolean,
 				value: false
 			},
-			_full: {
+			full: {
 				type: Boolean,
 				value: false
 			},
-			_maxBadges: { type: Number },
+			maxBadges: { type: Number },
 			isEmptyLeaderboard: { type: Boolean }
 		};
 	}
@@ -150,7 +150,7 @@ class App extends BaseMixin(LitElement) {
 
 		const baseUrl = import.meta.url;
 		this.emptyImage = new URL('../../images/leaderboard-empty-state.svg', baseUrl);
-		this._maxBadges = maxMobileBadges;
+		this.maxBadges = maxMobileBadges;
 	}
 
 	firstUpdated() {
@@ -191,7 +191,7 @@ class App extends BaseMixin(LitElement) {
 		}
 		return html`
 			${dialog}
-			<d2l-resize-aware class="resizeContainer" @d2l-resize-aware-resized=${this._handleResized} ?mobile="${this._mobile}" ?full="${this._full}">
+			<d2l-resize-aware @d2l-resize-aware-resized=${this._handleResized} ?mobile="${this.mobile}" ?full="${this.full}">
 				<d2l-list aria-busy="${!this.doneLoading}">
 					${listContent}
 				</d2l-list>
@@ -212,9 +212,9 @@ class App extends BaseMixin(LitElement) {
 					?myAward=${isMyAward} 
 					.userData=${item} 
 					?sortByCreditsConfig=${this.sortByCreditsConfig} 
-					?_mobile="${this._mobile}" 
-					?_full="${this._full}"
-					_maxBadges="${this._maxBadges}">
+					?mobile="${this.mobile}" 
+					?full="${this.full}"
+					maxBadges="${this.maxBadges}">
 				</leaderboard-row>
 			</d2l-list-item>
 		`;
@@ -265,8 +265,6 @@ class App extends BaseMixin(LitElement) {
 		if (!e || !e.detail || !e.detail.current) {
 			return;
 		}
-		
-		console.log('resize me', e.detail.current.width);
 
 		const currentWidth = e.detail.current.width;
 		const mobile = currentWidth <= mobileWidthMax;
@@ -278,10 +276,10 @@ class App extends BaseMixin(LitElement) {
 		} else {
 			maxBadges = maxFullBadges;
 		}
-		if (this._mobile !== mobile || this._full !== full || this._maxBadges !== maxBadges) {
-			this._mobile = mobile;
-			this._full = full;
-			this._maxBadges = maxBadges;
+		if (this.mobile !== mobile || this.full !== full || this.maxBadges !== maxBadges) {
+			this.mobile = mobile;
+			this.full = full;
+			this.maxBadges = maxBadges;
 
 			await this.requestUpdate();
 		}

--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -20,11 +20,16 @@ import '@brightspace-ui/core/components/list/list-item.js';
 import 'd2l-users/components/d2l-profile-image.js';
 import './leaderboard-row.js';
 
+import { BadgeImageSize, PanelPadding } from '../constants/constants';
 import { bodyStandardStyles, heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { BaseMixin } from '../mixins/base-mixin.js';
 
 import { LeaderboardService } from '../services/awards-leaderboard-service.js';
+const mobileWidthMax = 700;
+const fullWidthMin = 950;
+const maxFullBadges = 10;
+const maxMobileBadges = 8;
 
 class App extends BaseMixin(LitElement) {
 
@@ -34,6 +39,15 @@ class App extends BaseMixin(LitElement) {
 			userId: { type: Number },
 			sortByCreditsConfig: { type: Boolean },
 			doneLoading: { type: Boolean },
+			_mobile: {
+				type: Boolean,
+				value: false
+			},
+			_full: {
+				type: Boolean,
+				value: false
+			},
+			_maxBadges: { type: Number },
 			isEmptyLeaderboard: { type: Boolean }
 		};
 	}
@@ -47,6 +61,9 @@ class App extends BaseMixin(LitElement) {
 				max-height: 420px;
 				overflow: hidden;
 				overflow-y: auto;
+			}
+			d2l-resize-aware {
+				width: 100%;
 			}
 			.myAwardItem {
 				background-color: var(--d2l-color-celestine-plus-2);
@@ -133,6 +150,7 @@ class App extends BaseMixin(LitElement) {
 
 		const baseUrl = import.meta.url;
 		this.emptyImage = new URL('../../images/leaderboard-empty-state.svg', baseUrl);
+		this._maxBadges = maxMobileBadges;
 	}
 
 	firstUpdated() {
@@ -173,9 +191,11 @@ class App extends BaseMixin(LitElement) {
 		}
 		return html`
 			${dialog}
-			<d2l-list aria-busy="${!this.doneLoading}">
-				${listContent}
-			</d2l-list>
+			<d2l-resize-aware class="resizeContainer" @d2l-resize-aware-resized=${this._handleResized} ?mobile="${this._mobile}" ?full="${this._full}">
+				<d2l-list aria-busy="${!this.doneLoading}">
+					${listContent}
+				</d2l-list>
+			</d2l-resize-aware>			
 		`;
 	}
 
@@ -188,7 +208,14 @@ class App extends BaseMixin(LitElement) {
 		}
 		return html`
 			<d2l-list-item class="${ isMyAward ? 'myAwardItem' : '' }">
-				<leaderboard-row ?myAward=${isMyAward} .userData=${item} ?sortByCreditsConfig=${this.sortByCreditsConfig}></leaderboard-row>
+				<leaderboard-row 
+					?myAward=${isMyAward} 
+					.userData=${item} 
+					?sortByCreditsConfig=${this.sortByCreditsConfig} 
+					?_mobile="${this._mobile}" 
+					?_full="${this._full}"
+					_maxBadges="${this._maxBadges}">
+				</leaderboard-row>
 			</d2l-list-item>
 		`;
 	}
@@ -232,6 +259,32 @@ class App extends BaseMixin(LitElement) {
 			return;
 		}
 		this.myAwards = myAwards;
+	}
+
+	async _handleResized(e) {
+		if (!e || !e.detail || !e.detail.current) {
+			return;
+		}
+		
+		console.log('resize me', e.detail.current.width);
+
+		const currentWidth = e.detail.current.width;
+		const mobile = currentWidth <= mobileWidthMax;
+		const full = currentWidth > fullWidthMin;
+		let maxBadges;
+		if (!full) {
+			const awardMaxWidth = Math.floor((currentWidth - PanelPadding * 2 - BadgeImageSize + 10) / (BadgeImageSize + 10));
+			maxBadges = awardMaxWidth > maxMobileBadges ? maxMobileBadges : awardMaxWidth;
+		} else {
+			maxBadges = maxFullBadges;
+		}
+		if (this._mobile !== mobile || this._full !== full || this._maxBadges !== maxBadges) {
+			this._mobile = mobile;
+			this._full = full;
+			this._maxBadges = maxBadges;
+
+			await this.requestUpdate();
+		}
 	}
 
 	_isEmptyLeaderboard() {

--- a/src/components/leaderboard-row.js
+++ b/src/components/leaderboard-row.js
@@ -27,15 +27,15 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 			userData: { type: Object },
 			myAward: { type: Boolean },
 			sortByCreditsConfig: { type: Boolean },
-			_mobile: {
+			mobile: {
 				type: Boolean,
 				value: false
 			},
-			_full: {
+			full: {
 				type: Boolean,
 				value: false
 			},
-			_maxBadges: { type: Number },
+			maxBadges: { type: Number },
 			_displayedBadges: { type: Number }
 		};
 	}
@@ -96,17 +96,17 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 				padding-left: 0px;
 				padding-right: 10px;
 			}
-			.resizeContainer[full] .creditCount {
+			:host([full]) .creditCount {
 				flex-direction: row;
 				width: 35%;
 			}
-			.resizeContainer[full] .displayName {  
+			:host([full]) .displayName {  
 				line-height: 1rem;
 				overflow: hidden;
 				text-overflow: ellipsis;
 				width: 70%;
 			}
-			.resizeContainer[full] .displayNumber {
+			:host([full]) .displayNumber {
 				align-items: center;
 				display: flex;
 				width: 30%;
@@ -150,7 +150,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 		const userAwards = html`${this._getAwardsDisplay()}`;
 
 		let expandPanel;
-		if (this._mobile) {
+		if (this.mobile) {
 			expandPanel = html`
 				<div class="panel"> 
 					${userAwards}
@@ -158,7 +158,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 			`;
 		}
 		let sidePanel;
-		if (this._mobile) {
+		if (this.mobile) {
 			sidePanel = html`
 				
 			`;
@@ -167,7 +167,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 		}
 
 		let displayNumber;
-		if (this._full) {
+		if (this.full) {
 			displayNumber = html`
 				<div class='d2l-body-standard noMargin displayNumber'>${this._getDisplayNumber()}</div>
 			`;
@@ -177,11 +177,11 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 			`;
 		}
 
-		const fontStyle = this._full ? 'd2l-body-standard' : 'd2l-body-compact';
+		const fontStyle = this.full ? 'd2l-body-standard' : 'd2l-body-compact';
 
 		const isDisabled = this.userData.TotalAwardCount === 0 ? true : false;
 
-		if (this._mobile) {
+		if (this.mobile) {
 			return html`
 				<d2l-labs-accordion>
 					<d2l-labs-accordion-collapse flex icon-has-padding ?disabled="${isDisabled}">
@@ -246,7 +246,7 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 	}
 
 	_createAwardEntry(award) {
-		if (this._displayedBadges > (this._maxBadges - 1)) {
+		if (this._displayedBadges > (this.maxBadges - 1)) {
 			return;
 		}
 		this._displayedBadges = this._displayedBadges + 1;
@@ -298,8 +298,8 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 	}
 
 	_getExtraAwardCount() {
-		if (this.userData.TotalAwardCount > this._maxBadges) {
-			const extraCount = this.userData.TotalAwardCount - this._maxBadges;
+		if (this.userData.TotalAwardCount > this.maxBadges) {
+			const extraCount = this.userData.TotalAwardCount - this.maxBadges;
 			return extraCount;
 		}
 		return 0;

--- a/src/components/leaderboard-row.js
+++ b/src/components/leaderboard-row.js
@@ -14,16 +14,11 @@
 import './award-issued.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import 'd2l-resize-aware/d2l-resize-aware.js';
-import { BadgeImageSize, PanelPadding, TopStyleLimit } from '../constants/constants';
 import { bodyCompactStyles, bodySmallStyles  } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement, unsafeCSS } from 'lit-element/lit-element.js';
+import { PanelPadding, TopStyleLimit } from '../constants/constants';
 import { BaseMixin } from '../mixins/base-mixin.js';
 import { LeaderboardRoutes } from '../helpers/leaderboardRoutes';
-
-const mobileWidthMax = 700;
-const fullWidthMin = 950;
-const maxMobileBadges = 8;
-const maxFullBadges = 10;
 
 class LeaderboardRow extends BaseMixin(LitElement) {
 
@@ -50,9 +45,6 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 			bodyCompactStyles,
 			bodySmallStyles,
 			css`
-			d2l-resize-aware {
-				width: 100%;
-			}
             .awardRow {
 				align-items: center;
 				display: flex;
@@ -151,12 +143,6 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 		];
 	}
 
-	constructor() {
-		super();
-
-		this._maxBadges = maxMobileBadges;
-	}
-
 	render() {
 		if (this.userData === undefined) {
 			return;
@@ -197,69 +183,65 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 
 		if (this._mobile) {
 			return html`
-				<d2l-resize-aware class="resizeContainer" @d2l-resize-aware-resized=${this._handleResized} ?mobile="${this._mobile}" ?full="${this._full}">
-					<d2l-labs-accordion>
-						<d2l-labs-accordion-collapse flex icon-has-padding ?disabled="${isDisabled}">
-							<div class='awardRow' ?myAward="${this.myAward}" slot="header">
-								<div class="ranking">
-									<div 
-										class="awardRank ${fontStyle}" 
-										role="img"
-										?topRank="${this.userData.Rank <= TopStyleLimit}" 
-										aria-label="${this.localize('rankingAria', {rank:`${this.userData.Rank}`})}">
-										${this.userData.Rank}
-									</div>
-								</div>
-								<d2l-profile-image
-									class="profileImage"
-									href="${LeaderboardRoutes.ProfileImage(this.userData.UserId)}"
-									medium
-									token="token"
-									aria-hidden="true">
-								</d2l-profile-image>
-								<div class='creditCount'>
-									<div class='${fontStyle} noMargin displayName'>${this.userData.DisplayName}</div>
-									${displayNumber}
-								</div>
-								<div class="side">
-									${sidePanel}
+				<d2l-labs-accordion>
+					<d2l-labs-accordion-collapse flex icon-has-padding ?disabled="${isDisabled}">
+						<div class='awardRow' ?myAward="${this.myAward}" slot="header">
+							<div class="ranking">
+								<div 
+									class="awardRank ${fontStyle}" 
+									role="img"
+									?topRank="${this.userData.Rank <= TopStyleLimit}" 
+									aria-label="${this.localize('rankingAria', {rank:`${this.userData.Rank}`})}">
+									${this.userData.Rank}
 								</div>
 							</div>
-							${expandPanel}
-						</d2l-labs-accordion-collapse>
-					</d2l-labs-accordion>
-				</d2l-resize-aware>
+							<d2l-profile-image
+								class="profileImage"
+								href="${LeaderboardRoutes.ProfileImage(this.userData.UserId)}"
+								medium
+								token="token"
+								aria-hidden="true">
+							</d2l-profile-image>
+							<div class='creditCount'>
+								<div class='${fontStyle} noMargin displayName'>${this.userData.DisplayName}</div>
+								${displayNumber}
+							</div>
+							<div class="side">
+								${sidePanel}
+							</div>
+						</div>
+						${expandPanel}
+					</d2l-labs-accordion-collapse>
+				</d2l-labs-accordion>
 			`;
 		}
 		return html`
-			<d2l-resize-aware class="resizeContainer" @d2l-resize-aware-resized=${this._handleResized} ?mobile="${this._mobile}" ?full="${this._full}">
-				<div class='awardRow' ?myAward="${this.myAward}">
-					<div class="ranking">	
-						<div 
-							class="awardRank ${fontStyle}" 
-							role="img" 
-							?topRank="${this.userData.Rank <= TopStyleLimit}" 
-							aria-label="${this.localize('rankingAria', {rank:`${this.userData.Rank}`})}">
-							${this.userData.Rank}
-						</div>
-					</div>
-					<d2l-profile-image
-						class="profileImage"
-						href="${LeaderboardRoutes.ProfileImage(this.userData.UserId)}"
-						medium
-						token="token"
-						aria-hidden="true">
-					</d2l-profile-image>
-					<div class='creditCount'>
-						<div class='${fontStyle} noMargin displayName'>${this.userData.DisplayName}</div>
-						${displayNumber}
-					</div>
-					<div class="side">
-						${sidePanel}
+			<div class='awardRow' ?myAward="${this.myAward}">
+				<div class="ranking">	
+					<div 
+						class="awardRank ${fontStyle}" 
+						role="img" 
+						?topRank="${this.userData.Rank <= TopStyleLimit}" 
+						aria-label="${this.localize('rankingAria', {rank:`${this.userData.Rank}`})}">
+						${this.userData.Rank}
 					</div>
 				</div>
-				${expandPanel}
-			</d2l-resize-aware>
+				<d2l-profile-image
+					class="profileImage"
+					href="${LeaderboardRoutes.ProfileImage(this.userData.UserId)}"
+					medium
+					token="token"
+					aria-hidden="true">
+				</d2l-profile-image>
+				<div class='creditCount'>
+					<div class='${fontStyle} noMargin displayName'>${this.userData.DisplayName}</div>
+					${displayNumber}
+				</div>
+				<div class="side">
+					${sidePanel}
+				</div>
+			</div>
+			${expandPanel}
 		`;
 	}
 
@@ -321,30 +303,6 @@ class LeaderboardRow extends BaseMixin(LitElement) {
 			return extraCount;
 		}
 		return 0;
-	}
-
-	async _handleResized(e) {
-		if (!e || !e.detail || !e.detail.current) {
-			return;
-		}
-
-		const currentWidth = e.detail.current.width;
-		const mobile = currentWidth <= mobileWidthMax;
-		const full = currentWidth > fullWidthMin;
-		let maxBadges;
-		if (!full) {
-			const awardMaxWidth = Math.floor((currentWidth - PanelPadding * 2 - BadgeImageSize + 10) / (BadgeImageSize + 10));
-			maxBadges = awardMaxWidth > maxMobileBadges ? maxMobileBadges : awardMaxWidth;
-		} else {
-			maxBadges = maxFullBadges;
-		}
-		if (this._mobile !== mobile || this._full !== full || this._maxBadges !== maxBadges) {
-			this._mobile = mobile;
-			this._full = full;
-			this._maxBadges = maxBadges;
-
-			await this.requestUpdate();
-		}
 	}
 
 	_hasAwardsToDisplay() {

--- a/test/awards-leaderboard-ui-tests.html
+++ b/test/awards-leaderboard-ui-tests.html
@@ -72,6 +72,41 @@
                     const ret = awardsLeaderboard._createLeaderboardEntry(item, false);
                     expect(ret).to.be.undefined;
                 });
+                it('should return true mobile, false full match the mobile value', () => {
+                    const e = { detail: { current: { width: 700}}};
+                    const ret = awardsLeaderboard._handleResized(e);
+                    expect(awardsLeaderboard.mobile).to.be.true;
+                    expect(awardsLeaderboard.full).to.be.false;
+                    expect(awardsLeaderboard.maxBadges).to.equal(8);
+                });
+                it('should return true mobile, false full for tiny', () => {
+                    const e = { detail: { current: { width: 200}}};
+                    const ret = awardsLeaderboard._handleResized(e);
+                    expect(awardsLeaderboard.mobile).to.be.true;
+                    expect(awardsLeaderboard.full).to.be.false;
+                    expect(awardsLeaderboard.maxBadges).to.equal(3);
+                });
+                it('should return true mobile, false full for just over mobile', () => {
+                    const e = { detail: { current: { width: 701}}};
+                    const ret = awardsLeaderboard._handleResized(e);
+                    expect(awardsLeaderboard.mobile).to.be.false;
+                    expect(awardsLeaderboard.full).to.be.false;
+                    expect(awardsLeaderboard.maxBadges).to.equal(8);
+                });
+                it('should return false mobile, false full for under full', () => {
+                    const e = { detail: { current: { width: 900}}};
+                    const ret = awardsLeaderboard._handleResized(e);
+                    expect(awardsLeaderboard.mobile).to.be.false;
+                    expect(awardsLeaderboard.full).to.be.false;
+                    expect(awardsLeaderboard.maxBadges).to.equal(8);
+                });
+                it('should return false mobile, true full for over full', () => {
+                    const e = { detail: { current: { width: 951}}};
+                    const ret = awardsLeaderboard._handleResized(e);
+                    expect(awardsLeaderboard.mobile).to.be.false;
+                    expect(awardsLeaderboard.full).to.be.true;
+                    expect(awardsLeaderboard.maxBadges).to.equal(10);
+                });
             });
         });
     </script>

--- a/test/leaderboard-row-tests.html
+++ b/test/leaderboard-row-tests.html
@@ -64,17 +64,20 @@
                 it('should not return award, displayed more than max', () => {
                     const award = { UserId: 1234, TotalAwardCount: 3 };
                     leaderboardRow._displayedBadges = 100;
+                    leaderboardRow.maxBadges = 8;
                     const ret = leaderboardRow._createAwardEntry(award);
                     expect(ret).to.be.undefined;
                 });
                 it('should not return award displayed same as max', () => {
                     const award = { UserId: 1234, TotalAwardCount: 3 };
                     leaderboardRow._displayedBadges = 8;
+                    leaderboardRow.maxBadges = 8;
                     const ret = leaderboardRow._createAwardEntry(award);
                     expect(ret).to.be.undefined;
                 });
                 it('should have extra count of badges for display', () => {
                     const totalAwards = 20;
+                    leaderboardRow.maxBadges = 8;
                     leaderboardRow.userData = {
                         "UserId": 1234, 
                         "TotalAwardCount": totalAwards,
@@ -143,41 +146,6 @@
                     leaderboardRow.userData = { UserId: 1234, TotalCreditCount: 1 };
                     const ret = leaderboardRow._getDisplayNumber();
                     expect(ret).to.equal('1 credit');
-                });
-                it('should return true mobile, false full match the mobile value', () => {
-                    const e = { detail: { current: { width: 700}}};
-                    const ret = leaderboardRow._handleResized(e);
-                    expect(leaderboardRow._mobile).to.be.true;
-                    expect(leaderboardRow._full).to.be.false;
-                    expect(leaderboardRow._maxBadges).to.equal(8);
-                });
-                it('should return true mobile, false full for tiny', () => {
-                    const e = { detail: { current: { width: 200}}};
-                    const ret = leaderboardRow._handleResized(e);
-                    expect(leaderboardRow._mobile).to.be.true;
-                    expect(leaderboardRow._full).to.be.false;
-                    expect(leaderboardRow._maxBadges).to.equal(3);
-                });
-                it('should return true mobile, false full for just over mobile', () => {
-                    const e = { detail: { current: { width: 701}}};
-                    const ret = leaderboardRow._handleResized(e);
-                    expect(leaderboardRow._mobile).to.be.false;
-                    expect(leaderboardRow._full).to.be.false;
-                    expect(leaderboardRow._maxBadges).to.equal(8);
-                });
-                it('should return false mobile, false full for under full', () => {
-                    const e = { detail: { current: { width: 900}}};
-                    const ret = leaderboardRow._handleResized(e);
-                    expect(leaderboardRow._mobile).to.be.false;
-                    expect(leaderboardRow._full).to.be.false;
-                    expect(leaderboardRow._maxBadges).to.equal(8);
-                });
-                it('should return false mobile, true full for over full', () => {
-                    const e = { detail: { current: { width: 951}}};
-                    const ret = leaderboardRow._handleResized(e);
-                    expect(leaderboardRow._mobile).to.be.false;
-                    expect(leaderboardRow._full).to.be.true;
-                    expect(leaderboardRow._maxBadges).to.equal(10);
                 });
             });
         });


### PR DESCRIPTION
The purpose of this is to help with performance - Before this change, we had a resize-aware for each row. (Now we just have one per widget).
There were instances where the rows had varying widths - Not yet sure if this will help but 🤞 hoping

----Best to review this ignoring whitespaces as I've removed tabs