### PR TITLE
DE39389 Add word-break as temporary fix for tooltip

### DIFF
--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -46,6 +46,9 @@ class AwardIssued extends BaseMixin(LitElement) {
 				margin-right: 0px;
 				text-decoration: none;
 			}
+			d2l-tooltip {
+				word-break: break-all;
+			}
 			`
 		];
 	}


### PR DESCRIPTION
* Discussed this with Allan Kerr and this was the solution he said to use. It does seem to work on tooltip demo page. This is okay for now
--Thanks Allan!