### PR TITLE
US115049 Fix accessibility for FF with button and Firefox

### DIFF
--- a/src/components/award-issued.js
+++ b/src/components/award-issued.js
@@ -62,14 +62,15 @@ class AwardIssued extends BaseMixin(LitElement) {
 
 		this.badgeId = `Badge_${this.award.Award.AwardId}`;
 		return html`
-			<button 
-				id="${this.badgeId}" 
-				style="background-image:url(${this.award.Award.ImageData.Path})" 
+			<button
+				id="${this.badgeId}"
+				style="background-image:url(${this.award.Award.ImageData.Path})"
 				tabindex="0"
-				@click="${this._awardClick}" 
-				class="awardBtn">
+				@click="${this._awardClick}"
+				class="awardBtn"
+			>
 			</button>
-			<d2l-tooltip for="${this.badgeId}">${this.award.Award.Title}</d2l-tooltip>
+			<d2l-tooltip for="${this.badgeId}" for-type="label">${this.award.Award.Title}</d2l-tooltip>
     	`;
 	}
 


### PR DESCRIPTION
* Previously wasn't reading the name of the button correctly in some situations / directions
* If I added a label, it would read the name twice in Chrome