### PR TITLE
DE39964 Use older version of core until fix available

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/Brightspace/awards-leaderboard-ui#readme",
   "dependencies": {
     "@brightspace-ui-labs/accordion": "^2",
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "1.58.0",
     "@polymer/polymer": "^3",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",


### PR DESCRIPTION
This is to use before new version of list was made to core.
It's causing issues with leaderboard

[DE39964](https://rally1.rallydev.com/#/17843134395d/custom/10153168813?detail=%2Fdefect%2F408379024572)