### PR TITLE
Revert "Bump @brightspace-ui/core from 1.58.0 to 1.63.3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/Brightspace/awards-leaderboard-ui#readme",
   "dependencies": {
     "@brightspace-ui-labs/accordion": "^2",
-    "@brightspace-ui/core": "1.63.3",
+    "@brightspace-ui/core": "1.58.0",
     "@polymer/polymer": "^3",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",


### PR DESCRIPTION
Reverts Brightspace/awards-leaderboard-ui#101.

This is since newer versions have issues with the list component. See #100.