### PR TITLE
Don't use our own auth,  rely on BSI's

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "@brightspace-ui/core": "^1",
     "@polymer/polymer": "^3",
     "@webcomponents/webcomponentsjs": "^2",
-    "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
-    "d2l-fetch-auth": "^1.5.2",
     "d2l-html-editor": "github:Brightspace/d2l-html-editor#semver:^2",
     "d2l-inputs": "github:BrightspaceUI/inputs#semver:^2",
     "d2l-loading-spinner": "github:BrightspaceUI/loading-spinner#semver:^7",

--- a/src/services/awards-leaderboard-service.js
+++ b/src/services/awards-leaderboard-service.js
@@ -1,15 +1,5 @@
 import { ClasslistAwardSortByAwards, ClasslistAwardSortByCredits } from '../constants/constants';
-import { d2lfetch } from 'd2l-fetch/src/index';
-import fetchAuthFramed from 'd2l-fetch-auth/es6/d2lfetch-auth-framed';
 import { LeaderboardRoutes } from '../helpers/leaderboardRoutes';
-
-d2lfetch.use({
-	name: 'auth',
-	fn: fetchAuthFramed,
-	options: {
-		enableTokenCache: true
-	}
-});
 
 export class LeaderboardService {
 


### PR DESCRIPTION
This is based on a defect that came in,  whereby if leaderboard was on a course home page, you couldn't change course banners.

This is due to us still using FRA auth, and breaking things. 