### PR TITLE
Fix width of skeleton overlay

### DIFF
--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -63,6 +63,9 @@ class App extends BaseMixin(LitElement) {
 				overflow: hidden;
 				overflow-y: auto;
 			}
+			d2l-list-item-content {
+				width: 100%;
+			}
 			d2l-resize-aware {
 				width: 100%;
 			}


### PR DESCRIPTION
* After list changes, skeleton overlay didn't span the width

![image](https://user-images.githubusercontent.com/17279735/93266527-31b05f80-f778-11ea-9d4c-6997166ed8ac.png)
