### PR TITLE
DE40713 Use custom list instead of d2l list 

### DIFF
--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -63,6 +63,9 @@ class App extends BaseMixin(LitElement) {
 				overflow: hidden;
 				overflow-y: auto;
 			}
+			d2l-list-item-content {
+				width: 100%;
+			}
 			d2l-resize-aware {
 				width: 100%;
 			}

--- a/src/components/awards-leaderboard-ui.js
+++ b/src/components/awards-leaderboard-ui.js
@@ -63,17 +63,8 @@ class App extends BaseMixin(LitElement) {
 				overflow: hidden;
 				overflow-y: auto;
 			}
-			d2l-list-item-content {
-				width: 100%;
-			}
 			d2l-resize-aware {
 				width: 100%;
-			}
-			.d2l-my-award-item {
-				background-color: var(--d2l-color-celestine-plus-2);
-				bottom: 0;
-				position: -webkit-sticky; /* Safari */
-				position: sticky;
 			}
 			@keyframes loadingPulse {
 				0% { background-color: var(--d2l-color-sylvite); }
@@ -213,16 +204,14 @@ class App extends BaseMixin(LitElement) {
 			isMyAward = true;
 		}
 		return html`
-			<d2l-list-item class="${ isMyAward ? 'd2l-my-award-item' : '' }">
-				<d2l-leaderboard-row
-					?my-award=${isMyAward}
-					.userData=${item}
-					?sort-by-credits-config=${this.sortByCreditsConfig}
-					?mobile="${this.mobile}"
-					?full="${this.full}"
-					max-badges="${this.maxBadges}">
-				</d2l-leaderboard-row>
-			</d2l-list-item>
+			<d2l-leaderboard-row
+				?my-award=${isMyAward}
+				.userData=${item}
+				?sort-by-credits-config=${this.sortByCreditsConfig}
+				?mobile="${this.mobile}"
+				?full="${this.full}"
+				max-badges="${this.maxBadges}">
+			</d2l-leaderboard-row>
 		`;
 	}
 


### PR DESCRIPTION
* Refactoring leaderboard-row to be a custom list item
* Add list style back in for skeleton cb69b67
-- This was taken from @zinabat PR #120

---
## Context
[DE40713](https://rally1.rallydev.com/#/detail/defect/438139983160?fdp=true)
A class was being overwritten due to style specifications in core.

## Changes
Creates a **custom list item** rather than relying on the `d2l-list-item` in core. Why?
- Use case for award leaderboard is different from that in core
- Needs to support custom style (for highlighting my award)
- Mixins from core allow us to do this easily

Refactoring
- Attributes in lit-element **are lowercase** and have been converted
- Style classes are always prefixed with `d2l-`
- Deduplicated some template code

## UX Result
![Screen Shot 2020-09-28 at 11 51 57 AM](https://user-images.githubusercontent.com/2412740/94456245-7927ea00-0181-11eb-9bf5-040ca97d3ed6.png)

## Quality
Manually tested with demo page.

To test:
```bash
npm install
npm run start:dev
```
Visit http://127.0.0.1:3000/components/d2l-awards-leaderboard-ui/demo/index.html

- [x] Chrome
- [x] Firefox
- [x] Legacy Edge
- [x] Safari
- [ ] CrEdge